### PR TITLE
Add Found items landing page

### DIFF
--- a/DOCS_UPDATES.md
+++ b/DOCS_UPDATES.md
@@ -55,3 +55,4 @@ Record of notable changes to code and docs. Add entries with date, scope, and br
 - Frontend: report forms now capture campus zone, tags, and document URLs; Home/Search pages consume the new API and Item Details renders document links.
 - Docs: README/API references updated, storage rules documented, and noted Firebase UTC+8 assumption for timestamps.
 - Frontend: Added Lost Items landing page with search, sort, and report CTA linking to the existing lost report form.
+- Frontend: Added Found Items landing page mirroring the lost layout with search, sort, and a report shortcut to the existing found form.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -15,7 +15,13 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
+      sourceType: 'module',
       globals: globals.browser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
     },
   },
 ])

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ const primaryNav = [
   { to: '/', label: 'Home', end: true },
   { to: '/get-started', label: 'Get Started' },
   { to: '/lost', label: 'Lost' },
-  { to: '/items/new/found', label: 'Found' },
+  { to: '/found', label: 'Found' },
 ];
 
 export default function App() {

--- a/frontend/src/pages/FoundPage.css
+++ b/frontend/src/pages/FoundPage.css
@@ -1,0 +1,203 @@
+.found-page {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.found-page__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.found-page__report {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.75rem;
+  border-radius: 14px;
+  background: var(--color-gold);
+  color: var(--color-burgundy-dark);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  box-shadow: 0 18px 32px -24px rgba(255, 203, 51, 0.55);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.found-page__report:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 38px -26px rgba(102, 11, 5, 0.35);
+}
+
+.found-page__report-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(62, 7, 3, 0.12);
+  font-weight: 700;
+}
+
+.found-page__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.found-search {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+  border: 2px solid var(--color-gold);
+  border-radius: 999px;
+  padding: 0.35rem 0.5rem;
+  background: #fff;
+  flex: 1 1 420px;
+}
+
+.found-search__label {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  color: var(--muted-color);
+}
+
+.found-search input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font: inherit;
+  padding: 0 0.5rem;
+}
+
+.found-search__submit {
+  border: none;
+  background: var(--color-burgundy);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.35rem 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.found-sort {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.found-sort label {
+  font-weight: 600;
+  color: var(--color-burgundy-dark);
+}
+
+.found-sort select {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 0.4rem 0.75rem;
+  font: inherit;
+}
+
+.found-status {
+  color: var(--muted-color);
+}
+
+.found-status--error {
+  color: #7f1d1d;
+}
+
+.found-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.found-card {
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  box-shadow: 0 18px 32px -28px rgba(62, 7, 3, 0.35);
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.found-card__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(255, 203, 51, 0.25);
+  color: var(--color-burgundy-dark);
+}
+
+.found-card__badge--claimed {
+  background: rgba(62, 7, 3, 0.12);
+  color: var(--color-burgundy);
+}
+
+.found-card__meta {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  color: var(--muted-color);
+}
+
+.found-card__time {
+  font-size: 0.85rem;
+  color: rgba(62, 7, 3, 0.6);
+}
+
+.found-card__tags {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.found-card__tags li {
+  background: rgba(255, 203, 51, 0.35);
+  color: var(--color-burgundy-dark);
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .found-page__report {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .found-sort {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/frontend/src/pages/FoundPage.jsx
+++ b/frontend/src/pages/FoundPage.jsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '../api/client';
+import './FoundPage.css';
+
+const formatter = new Intl.DateTimeFormat('en-PH', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+  timeZone: 'Asia/Manila',
+});
+
+function formatDate(value) {
+  if (!value) return 'Unknown time';
+  try {
+    return formatter.format(new Date(value));
+  } catch (error) {
+    return 'Unknown time';
+  }
+}
+
+const SORT_OPTIONS = [
+  { value: 'newest', label: 'Newest first' },
+  { value: 'oldest', label: 'Oldest first' },
+  { value: 'name', label: 'Name A-Z' }
+];
+
+export function FoundPage() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [appliedQuery, setAppliedQuery] = useState('');
+  const [sort, setSort] = useState('newest');
+
+  useEffect(() => {
+    let ignore = false;
+    const load = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const params = new URLSearchParams();
+        params.set('status', 'found');
+        params.set('page', '0');
+        params.set('pageSize', '60');
+        if (appliedQuery) {
+          params.set('q', appliedQuery);
+        }
+        const response = await api(`/api/items?${params.toString()}`);
+        if (!ignore) {
+          setItems(response?.items ?? []);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err?.message ?? 'Unable to load found items right now.');
+          setItems([]);
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      ignore = true;
+    };
+  }, [appliedQuery]);
+
+  const sortedItems = useMemo(() => {
+    const copy = [...items];
+    if (sort === 'oldest') {
+      copy.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+    } else if (sort === 'name') {
+      copy.sort((a, b) => (a.title || '').localeCompare(b.title || ''));
+    } else {
+      copy.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    }
+    return copy;
+  }, [items, sort]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    setAppliedQuery(searchTerm.trim());
+  };
+
+  return (
+    <div className="found-page">
+      <header className="found-page__header">
+        <h1>Found Items</h1>
+        <Link to="/items/new/found" className="found-page__report">
+          <span className="found-page__report-icon" aria-hidden="true">+</span>
+          <span>Report</span>
+        </Link>
+      </header>
+
+      <section className="found-page__controls" aria-label="Search found items">
+        <form className="found-search" onSubmit={handleSubmit}>
+          <label htmlFor="found-search-input" className="found-search__label">
+            <span aria-hidden="true">#</span>
+            <span className="sr-only">Item name</span>
+          </label>
+          <input
+            id="found-search-input"
+            type="search"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Item name"
+          />
+          <button type="submit" className="found-search__submit" aria-label="Search">
+            Search
+          </button>
+        </form>
+
+        <div className="found-sort">
+          <label htmlFor="found-sort-select">Sort</label>
+          <select
+            id="found-sort-select"
+            value={sort}
+            onChange={(event) => setSort(event.target.value)}
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      {loading ? (
+        <p className="found-status">Loading found reports...</p>
+      ) : error ? (
+        <p className="found-status found-status--error">{error}</p>
+      ) : sortedItems.length === 0 ? (
+        <p className="found-status">No found items reported yet. Try another search or file a report.</p>
+      ) : (
+        <ul className="found-grid">
+          {sortedItems.map((item) => (
+            <li key={item.id} className="found-card">
+              <div className={`found-card__badge found-card__badge--${item.status}`}>
+                {item.status}
+              </div>
+              <h2>
+                <Link to={`/items/${item.id}`}>{item.title}</Link>
+              </h2>
+              <p className="found-card__meta">
+                <span>{item.locationText}</span>
+                {item.campusZone ? <span>- {item.campusZone}</span> : null}
+              </p>
+              <p className="found-card__time">Updated {formatDate(item.createdAt)}</p>
+              {item.tags && item.tags.length > 0 ? (
+                <ul className="found-card__tags">
+                  {item.tags.slice(0, 4).map((tag) => (
+                    <li key={`${item.id}-${tag}`}>{tag}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -5,6 +5,7 @@ import { SearchPage } from './pages/SearchPage';
 import { ReportLostPage } from './pages/ReportLostPage';
 import { ReportFoundPage } from './pages/ReportFoundPage';
 import { LostPage } from './pages/LostPage';
+import { FoundPage } from './pages/FoundPage';
 import { ItemDetailsPage } from './pages/ItemDetailsPage';
 import { EditItemPage } from './pages/EditItemPage';
 import { ClaimItemPage } from './pages/ClaimItemPage';
@@ -32,6 +33,7 @@ export const router = createBrowserRouter([
       { path: 'get-started', element: <GetStartedPage /> },
       { path: 'search', element: <SearchPage /> },
       { path: 'lost', element: <LostPage /> },
+      { path: 'found', element: <FoundPage /> },
 
       { path: 'items/new/lost', element: <ProtectedRoute><ReportLostPage /></ProtectedRoute> },
       { path: 'items/new/found', element: <ProtectedRoute><ReportFoundPage /></ProtectedRoute> },


### PR DESCRIPTION
## Summary
- add a Found Items landing page mirroring the Lost layout with search, sort, and report CTA
- route the top navigation and router to the new Found page while keeping the existing report form
- tweak ESLint flat config so JSX syntax is parsed consistently

## Testing
- npm run lint *(fails: repository's baseline violates lint rules for unused React imports/components)*

------
https://chatgpt.com/codex/tasks/task_e_68d2823535948333b9eec94082bbe77d